### PR TITLE
Introducing own command handling

### DIFF
--- a/src/Bojler/ConfigHandler.php
+++ b/src/Bojler/ConfigHandler.php
@@ -10,7 +10,7 @@ class ConfigHandler
 
     public static function getInstance()
     {
-        if (self::$instance === null) {
+        if (is_null(self::$instance)) {
             self::$instance = new self();
         }
 

--- a/src/Bojler/ConfigHandler.php
+++ b/src/Bojler/ConfigHandler.php
@@ -8,7 +8,7 @@ class ConfigHandler
 
     private const CONFIG_PATH = 'param/config.json';
 
-    public static function getInstance()
+    public static function getInstance(): self
     {
         if (is_null(self::$instance)) {
             self::$instance = new self();

--- a/src/Bojler/CustomCommandClient.php
+++ b/src/Bojler/CustomCommandClient.php
@@ -50,7 +50,7 @@ class CustomCommandClient extends DiscordCommandClient
             }
 
             $command = $this->getCommand($command);
-            if ($command === null) {
+            if (is_null($command)) {
                 return;
             }
 

--- a/src/Bojler/CustomCommandClient.php
+++ b/src/Bojler/CustomCommandClient.php
@@ -2,6 +2,7 @@
 
 namespace Bojler;
 
+use Collator;
 use Discord\DiscordCommandClient;
 use Discord\Parts\Embed\Embed;
 use React\Promise\PromiseInterface;
@@ -9,9 +10,16 @@ use React\Promise\PromiseInterface;
 # TODO investigate and improve help message
 class CustomCommandClient extends DiscordCommandClient
 {
+    private Collator $collator;
+
     public function __construct(array $options = [])
     {
+        $own_options = $options['customOptions']; # TODO do some validation here as well
+        unset($options['customOptions']);
+
         parent::__construct($options);
+
+        $this->collator = new Collator($own_options['locale']);
 
         # This is completely idiotic, thank DiscordPHP
         $this->on('ready', $this->monkeyPatching(...));

--- a/src/Bojler/CustomCommandClient.php
+++ b/src/Bojler/CustomCommandClient.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Bojler;
+
+use Discord\DiscordCommandClient;
+use Discord\Parts\Embed\Embed;
+use React\Promise\PromiseInterface;
+
+# TODO investigate and improve help message
+class CustomCommandClient extends DiscordCommandClient
+{
+    public function __construct(array $options = [])
+    {
+        parent::__construct($options);
+
+        # This is completely idiotic, thank DiscordPHP
+        $this->on('ready', $this->monkeyPatching(...));
+    }
+
+    private function monkeyPatching()
+    {
+        $this->removeAllListeners('message');
+        $this->on('message', $this->baseMessageHandler(...));
+
+        if ($this->commandClientOptions['defaultHelpCommand']) {
+            $this->unregisterCommand('help');
+            $this->registerCommand(
+                'help',
+                $this->defaultHelp(...),
+                [
+                    'description' => 'Provides a list of commands available.',
+                    'usage' => '[command]',
+                ]
+            );
+        }
+    }
+
+    private function baseMessageHandler($message)
+    {
+        if ($message->author->id == $this->id) {
+            return;
+        }
+
+        if ($withoutPrefix = $this->checkForPrefix($message->content)) {
+            $args = mb_split(' +', $withoutPrefix);
+            $command = array_shift($args);
+
+            if ($command !== null && $this->commandClientOptions['caseInsensitiveCommands']) {
+                $command = strtolower($command);
+            }
+
+            $command = $this->getCommand($command);
+            if ($command === null) {
+                return;
+            }
+
+            $result = $command->handle($message, $args);
+            if (is_string($result)) {
+                $result = $message->reply($result);
+            }
+
+            if ($result instanceof PromiseInterface) {
+                $result->then(null, function (\Throwable $e) {
+                    $this->logger->warning($e->getTraceAsString());
+                });
+            }
+        }
+    }
+
+    private function defaultHelp($message, $args)
+    {
+        $prefix = str_replace((string) $this->user, '@' . $this->username, $this->commandClientOptions['prefix']);
+        $fullCommandString = implode(' ', $args);
+
+        if (count($args) > 0) {
+            $command = $this;
+            while (count($args) > 0) {
+                $commandString = array_shift($args);
+                $newCommand = $command->getCommand($commandString);
+
+                if (is_null($newCommand)) {
+                    return "The command {$commandString} does not exist.";
+                }
+
+                $command = $newCommand;
+            }
+
+            $help = $command->getHelp($prefix);
+
+            $embed = new Embed($this);
+            $embed->setAuthor($this->commandClientOptions['name'], $this->client->user->avatar)
+                ->setTitle($prefix . $fullCommandString . '\'s Help')
+                ->setDescription(! empty($help['longDescription']) ? $help['longDescription'] : $help['description'])
+                ->setFooter($this->commandClientOptions['name']);
+
+            if (! empty($help['usage'])) {
+                $embed->addFieldValues('Usage', '``' . $help['usage'] . '``', true);
+            }
+
+            if (! empty($this->aliases)) {
+                $aliasesString = '';
+                foreach ($this->aliases as $alias => $command) {
+                    if ($command != $commandString) {
+                        continue;
+                    }
+
+                    $aliasesString .= "{$alias}\r\n";
+                }
+
+                if (! empty($aliasesString)) {
+                    $embed->addFieldValues('Aliases', $aliasesString, true);
+                }
+            }
+
+            if (! empty($help['subCommandsHelp'])) {
+                foreach ($help['subCommandsHelp'] as $subCommandHelp) {
+                    $embed->addFieldValues($subCommandHelp['command'], $subCommandHelp['description'], true);
+                }
+            }
+
+            $message->channel->sendEmbed($embed);
+
+            return;
+        }
+
+        $embed = new Embed($this);
+        $embed->setAuthor($this->commandClientOptions['name'], $this->client->avatar)
+            ->setTitle($this->commandClientOptions['name'])
+            ->setType(Embed::TYPE_RICH)
+            ->setFooter($this->commandClientOptions['name']);
+
+        $commandsDescription = '';
+        $embedfields = [];
+        foreach ($this->commands as $command) {
+            $help = $command->getHelp($prefix);
+            $embedfields[] = [
+                'name' => $help['command'],
+                'value' => $help['description'],
+                'inline' => true,
+            ];
+            $commandsDescription .= "\n\n`" . $help['command'] . "`\n" . $help['description'];
+
+            foreach ($help['subCommandsHelp'] as $subCommandHelp) {
+                $embedfields[] = [
+                    'name' => $subCommandHelp['command'],
+                    'value' => $subCommandHelp['description'],
+                    'inline' => true,
+                ];
+                $commandsDescription .= "\n\n`" . $subCommandHelp['command'] . "`\n" . $subCommandHelp['description'];
+            }
+        }
+        // Use embed fields in case commands count is below limit
+        if (count($embedfields) <= 25) {
+            foreach ($embedfields as $field) {
+                $embed->addField($field);
+            }
+            $commandsDescription = '';
+        }
+
+        $embed->setDescription(substr($this->commandClientOptions['description'] . $commandsDescription, 0, 2048));
+
+        $message->channel->sendEmbed($embed);
+    }
+}

--- a/src/Bojler/DatabaseHandler.php
+++ b/src/Bojler/DatabaseHandler.php
@@ -11,7 +11,7 @@ class DatabaseHandler
 
     public static function getInstance(): self
     {
-        if (self::$instance === null) {
+        if (is_null(self::$instance)) {
             self::$instance = new self();
         }
 

--- a/src/Bojler/PlayerHandler.php
+++ b/src/Bojler/PlayerHandler.php
@@ -13,7 +13,7 @@ class PlayerHandler
 
     public static function getInstance()
     {
-        if (self::$instance === null) {
+        if (is_null(self::$instance)) {
             self::$instance = new self();
         }
 

--- a/src/Bojler/PlayerHandler.php
+++ b/src/Bojler/PlayerHandler.php
@@ -11,7 +11,7 @@ class PlayerHandler
 {
     private static $instance;
 
-    public static function getInstance()
+    public static function getInstance(): self
     {
         if (is_null(self::$instance)) {
             self::$instance = new self();
@@ -35,7 +35,7 @@ class PlayerHandler
         }
         $read_dict = json_decode($read_content, true);
         $this->player_dict = array_map(
-            fn ($player_data) => array_merge($this->default_player, $player_data),
+            fn($player_data) => array_merge($this->default_player, $player_data),
             $read_dict
         );
         $this->saveFile();

--- a/src/Bojler/functions/discord_util.php
+++ b/src/Bojler/functions/discord_util.php
@@ -118,3 +118,9 @@ function strikethrough(string $text): string
 {
     return $text === '' ? '' : "~~$text~~";
 }
+
+
+function italic(string $text): string
+{
+    return $text === '' ? '' : "_{$text}_";
+}

--- a/src/bot.php
+++ b/src/bot.php
@@ -9,6 +9,7 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 use Bojler\{
     ConfigHandler,
+    CustomCommandClient,
     DatabaseHandler,
     DictionaryType,
     GameStatus,
@@ -16,7 +17,6 @@ use Bojler\{
 };
 use Discord\Builders\MessageBuilder;
 use Symfony\Component\Dotenv\Dotenv;
-use Discord\DiscordCommandClient;
 use Discord\Parts\Channel\Message;
 use Discord\WebSockets\Intents;
 use Random\Randomizer;
@@ -243,7 +243,7 @@ const RNG = new Randomizer();
 const BOT_LOGGER = new Logger('bojlerLogger');
 BOT_LOGGER->pushHandler(new StreamHandler('php://stdout', Level::Warning));
 
-$bot = new DiscordCommandClient([
+$bot = new CustomCommandClient([
     'prefix' => 'b!',
     'token' => $_ENV['DC_TOKEN'],
     'description' => 'Szórakodtató bot',

--- a/src/bot.php
+++ b/src/bot.php
@@ -33,6 +33,7 @@ use function Bojler\{
     try_send_msg,
     game_highscore,
     hungarian_role,
+    italic,
     strikethrough
 };
 use function React\Async\await;
@@ -490,7 +491,8 @@ function remove(Message $ctx, $args)
     if (GAME_STATUS->found_words->contains($word)) {
         GAME_STATUS->removeWord($word);
         PlayerHandler::getInstance()->playerRemoveWord($ctx, GAME_STATUS->approvalStatus($word));
-        await($ctx->channel->sendMessage("Removed _{$word}_."));
+        $formatted_word = italic($word);
+        await($ctx->channel->sendMessage("Removed $formatted_word."));
     } else {
         await($ctx->channel->sendMessage("$word doesn't appear among the found solutions."));
     }
@@ -597,8 +599,8 @@ function hint_command(string $from_language)
             return;
         }
         $chosen_hint = $unfound_hint_list[array_rand($unfound_hint_list)];
-        $hint_content = get_translation($chosen_hint, new DictionaryType(GAME_STATUS->current_lang, $from_language));
-        await($ctx->channel->sendMessage("hint: _{$hint_content}_"));
+        $formatted_hint_content = italic(get_translation($chosen_hint, new DictionaryType(GAME_STATUS->current_lang, $from_language)));
+        await($ctx->channel->sendMessage("hint: $formatted_hint_content"));
         PlayerHandler::getInstance()->playerUsedHint($ctx, $chosen_hint);
     };
 }
@@ -710,8 +712,8 @@ function reveal(Message $ctx)
     $chosen_word = $left_hints[array_rand($left_hints)];
     $word_length = grapheme_strlen($chosen_word);
     $revealed_indices = RNG->pickArrayKeys(range(0, $word_length - 1), intdiv($word_length, 3));
-    $masked_word = masked_word($chosen_word, $revealed_indices);
-    await($ctx->channel->sendMessage("Hint: _{$masked_word}_"));
+    $formatted_masked_word = italic(masked_word($chosen_word, $revealed_indices));
+    await($ctx->channel->sendMessage("Hint: $formatted_masked_word"));
 }
 
 # Blocks the code - has to be at the bottom

--- a/src/bot.php
+++ b/src/bot.php
@@ -252,7 +252,10 @@ $bot = new CustomCommandClient([
         'intents' => Intents::getDefaultIntents()
         //      | Intents::MESSAGE_CONTENT, // Note: MESSAGE_CONTENT is privileged, see https://dis.gd/mcfaq
     ],
-    'caseInsensitiveCommands' => true
+    'caseInsensitiveCommands' => true,
+    'customOptions' => [
+        'locale' => CONFIG->getLocale('Hungarian') # TODO do something with this magic constant here
+    ]
 ]);
 
 # TODO more consistency about how the functions send the message? (not super important if we move to slash commands)

--- a/src/bot.php
+++ b/src/bot.php
@@ -251,7 +251,8 @@ $bot = new DiscordCommandClient([
         'logger' => BOT_LOGGER,
         'intents' => Intents::getDefaultIntents()
         //      | Intents::MESSAGE_CONTENT, // Note: MESSAGE_CONTENT is privileged, see https://dis.gd/mcfaq
-    ]
+    ],
+    'caseInsensitiveCommands' => true
 ]);
 
 # TODO more consistency about how the functions send the message? (not super important if we move to slash commands)

--- a/src/bot.php
+++ b/src/bot.php
@@ -483,7 +483,7 @@ $bot->registerCommand(
         [async(...), ensure_predicate(channel_valid(...)), needs_counting(...)],
         'remove'
     ),
-    ['description' => 'remove solution', 'aliases' => 'r']
+    ['description' => 'remove solution', 'aliases' => ['r']]
 );
 
 function remove(Message $ctx, $args)

--- a/style_guide.md
+++ b/style_guide.md
@@ -15,3 +15,5 @@ _Rationale_: it clearly communicates lack of interpolation - and following this 
 - message-based command handlers shouldn't return anything
 _Rationale_: the return value of command handlers _could_ be used the content of the reply to the message; however, this is not flexible enough and it's by no means obvious to somebody unfamiliar. It's a bad API not to be relied on. It would probably be harder to migrate from it as well.
 _Replacement_: `$ctx->reply($value)` (assuming `$ctx` as the message instance) instead of `return $value`.
+- `is_null` is the preferred way to do a `null`-check
+_Rationale_: in a well-designed codebase, `null`-checks are seldom used - `null` values shouldn't be propagated too much and in general missing values are a special enough case that might demand a design change overall. Since `is_null` is safe to use and stands out more than an `=== null` check, it's a good choice for presenting a special circumstance as special.


### PR DESCRIPTION
Fixes #12.
Affects #9 .

A new, monkey-patched version of `DiscordCommandClient` has been created. This makes it possible to provide a better `help` command, fix argument parsing and last but not least, NOT swallow Promise rejections without any trace.

A few minor refactors and fixes are also landing, see the commit history.