### PR TITLE
JSON migration part 2: archive games backup format

### DIFF
--- a/src/Bojler/ArchiveGameEntryData.php
+++ b/src/Bojler/ArchiveGameEntryData.php
@@ -42,7 +42,7 @@ class ArchiveGameEntryData
         $letters_sorted = $status->letters->list;
         $status->collator()->sort($letters_sorted);
         $ctor_dict['letters_sorted'] = $letters_sorted;
-        $ctor_dict['found_words'] = $status->foundWordsSorted();
+        $ctor_dict['found_words_sorted'] = $status->foundWordsSorted();
         $ctor_dict['game_number'] = $status->game_number;
         $ctor_dict['current_lang'] = $status->current_lang;
         return new self(...$ctor_dict);

--- a/src/Bojler/ArchiveGameEntryData.php
+++ b/src/Bojler/ArchiveGameEntryData.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Bojler;
+
+use Exception;
+
+class ArchiveGameEntryData
+{
+    private function __construct(
+        public private(set) array $letters_sorted,
+        public private(set) array $found_words_sorted,
+        public private(set) int $game_number,
+        public private(set) string $current_lang
+    ) {}
+
+    public static function fromLegacyFile(string $legacy_file, int $number): self
+    {
+        $lines = file($legacy_file, FILE_IGNORE_NEW_LINES);
+        $offset = 3 * ($number - 1);
+        [$languages_line, $letters_line, $words_line] = array_slice($lines, $offset, 3);
+        $ctor_dict = [];
+        $ctor_dict['letters_sorted'] = explode(' ', $letters_line);
+        $ctor_dict['found_words_sorted'] = $words_line === '' ? [] : explode(' ', $words_line);
+        # set language and game number
+        [$read_number, $read_lang] = explode(' ', $languages_line);
+        $read_number = grapheme_substr($read_number, 0, grapheme_strlen($read_number) - 1);
+        $read_lang = grapheme_substr($read_lang, 1, grapheme_strlen($read_lang) - 2);
+        $ctor_dict['game_number'] = intval($read_number);
+        $ctor_dict['current_lang'] = $read_lang;
+        return new self(...$ctor_dict);
+    }
+
+    public static function fromJsonFile(string $json_file, int $number): self
+    {
+        $entry = json_decode(file_get_contents($json_file), true)[$number - 1];
+        return new self(...$entry);
+    }
+
+    public static function fromStatusObject(GameStatus $status): self
+    {
+        $ctor_dict = [];
+        $letters_sorted = $status->letters->list;
+        $status->collator()->sort($letters_sorted);
+        $ctor_dict['letters_sorted'] = $letters_sorted;
+        $ctor_dict['found_words'] = $status->foundWordsSorted();
+        $ctor_dict['game_number'] = $status->game_number;
+        $ctor_dict['current_lang'] = $status->current_lang;
+        return new self(...$ctor_dict);
+    }
+
+    public function toLegacyEntry(): string
+    {
+        $space_separated_letters_alphabetic = implode(' ', $this->letters_sorted);
+        $space_separated_found_words_alphabetic = implode(' ', $this->found_words_sorted);
+        return <<<END
+            {$this->game_number}. ({$this->current_lang})
+            $space_separated_letters_alphabetic
+            $space_separated_found_words_alphabetic
+
+            END;
+    }
+}

--- a/src/Bojler/CurrentGameData.php
+++ b/src/Bojler/CurrentGameData.php
@@ -6,13 +6,15 @@ use Exception;
 
 class CurrentGameData
 {
-    public private(set) array $letters;
-    public private(set) array $found_words;
-    public private(set) int $game_number;
-    public private(set) string $current_lang;
-    public private(set) string $base_lang;
-    public private(set) string $planned_lang;
-    public private(set) string $max_saved_game;
+    private function __construct(
+        public private(set) array $letters,
+        public private(set) array $found_words,
+        public private(set) int $game_number,
+        public private(set) string $current_lang,
+        public private(set) string $base_lang,
+        public private(set) string $planned_lang,
+        public private(set) string $max_saved_game
+    ) {}
 
     public static function fromLegacyFile(string $legacy_file): CurrentGameData
     {
@@ -20,39 +22,35 @@ class CurrentGameData
         if ($content === false || count($content) < 10) {
             throw new Exception('Save file wrong.');
         }
-        $instance = new self();
+        $ctor_dict = [];
         # Current Game
-        $instance->letters = explode(' ', $content[1]);
-        $instance->found_words = $content[2] === '' ? [] : explode(' ', $content[2]);
-        $instance->game_number = (int) explode("\t", $content[3])[1];
-        $instance->current_lang = explode("\t", $content[4])[1];
+        $ctor_dict['letters'] = explode(' ', $content[1]);
+        $ctor_dict['found_words'] = $content[2] === '' ? [] : explode(' ', $content[2]);
+        $ctor_dict['game_number'] = (int) explode("\t", $content[3])[1];
+        $ctor_dict['current_lang'] = explode("\t", $content[4])[1];
         # General Settings
-        $instance->base_lang = explode("\t", $content[7])[1];
-        $instance->planned_lang = explode("\t", $content[8])[1];
-        $instance->max_saved_game = (int) explode("\t", $content[9])[1];
-        return $instance;
+        $ctor_dict['base_lang'] = explode("\t", $content[7])[1];
+        $ctor_dict['planned_lang'] = explode("\t", $content[8])[1];
+        $ctor_dict['max_saved_game'] = (int) explode("\t", $content[9])[1];
+        return new self(...$ctor_dict);
     }
 
     public static function fromJsonFile(string $json_file): CurrentGameData
     {
-        $content = json_decode(file_get_contents($json_file), false);
-        $instance = new self();
-        foreach (array_keys(get_class_vars($instance::class)) as $prop_name) {
-            $instance->$prop_name = $content->$prop_name;
-        }
-        return $instance;
+        $content = json_decode(file_get_contents($json_file), true);
+        return new self(...$content);
     }
 
     public static function fromStatusObject(GameStatus $status): CurrentGameData
     {
-        $instance = new self();
-        $instance->letters = $status->letters->list;
-        $instance->found_words = $status->found_words->toArray();
-        $instance->game_number = $status->game_number;
-        $instance->current_lang = $status->current_lang;
-        $instance->base_lang = $status->base_lang;
-        $instance->planned_lang = $status->planned_lang;
-        $instance->max_saved_game = $status->max_saved_game;
-        return $instance;
+        $ctor_dict = [];
+        $ctor_dict['letters'] = $status->letters->list;
+        $ctor_dict['found_words'] = $status->found_words->toArray();
+        $ctor_dict['game_number'] = $status->game_number;
+        $ctor_dict['current_lang'] = $status->current_lang;
+        $ctor_dict['base_lang'] = $status->base_lang;
+        $ctor_dict['planned_lang'] = $status->planned_lang;
+        $ctor_dict['max_saved_game'] = $status->max_saved_game;
+        return new self(...$ctor_dict);
     }
 }

--- a/src/Bojler/CurrentGameData.php
+++ b/src/Bojler/CurrentGameData.php
@@ -53,4 +53,22 @@ class CurrentGameData
         $ctor_dict['max_saved_game'] = $status->max_saved_game;
         return new self(...$ctor_dict);
     }
+
+    public function toLegacyEntry(): string
+    {
+        $space_separated_letters = implode(' ', $this->letters);
+        $space_separated_found_words = implode(' ', $this->found_words);
+        return <<<END
+            #Current Game
+            $space_separated_letters
+            $space_separated_found_words
+            Game Number\t{$this->game_number}
+            Game Language\t{$this->current_lang}
+
+            # General Settings
+            Base Language\t{$this->base_lang}
+            Planned Language\t{$this->planned_lang}
+            Saved Games\t{$this->max_saved_game}
+            END;
+    }
 }

--- a/src/Bojler/CurrentGameData.php
+++ b/src/Bojler/CurrentGameData.php
@@ -16,7 +16,7 @@ class CurrentGameData
         public private(set) string $max_saved_game
     ) {}
 
-    public static function fromLegacyFile(string $legacy_file): CurrentGameData
+    public static function fromLegacyFile(string $legacy_file): self
     {
         $content = file($legacy_file, FILE_IGNORE_NEW_LINES);
         if ($content === false || count($content) < 10) {
@@ -35,13 +35,13 @@ class CurrentGameData
         return new self(...$ctor_dict);
     }
 
-    public static function fromJsonFile(string $json_file): CurrentGameData
+    public static function fromJsonFile(string $json_file): self
     {
         $content = json_decode(file_get_contents($json_file), true);
         return new self(...$content);
     }
 
-    public static function fromStatusObject(GameStatus $status): CurrentGameData
+    public static function fromStatusObject(GameStatus $status): self
     {
         $ctor_dict = [];
         $ctor_dict['letters'] = $status->letters->list;

--- a/src/Bojler/DictionaryEntry.php
+++ b/src/Bojler/DictionaryEntry.php
@@ -17,7 +17,7 @@ class DictionaryEntry
     {
         $line_pieces = explode("\t", $line);
         /*debug purposes
-        if (count($line_pieces) != 3) {
+        if (count($line_pieces) !== 3) {
             var_dump($line_pieces);
         }
         */

--- a/src/Bojler/GameStatus.php
+++ b/src/Bojler/GameStatus.php
@@ -307,7 +307,7 @@ class GameStatus #not final because of mocking
         $language_in_parens = explode(' ', $lines[count($lines) - 3])[1];
         $language = grapheme_substr($language_in_parens, 1, grapheme_strlen($language_in_parens) - 2);
         echo $language;
-        if ($language != $this->current_lang) {
+        if ($language !== $this->current_lang) {
             return false;
         }
         if (count($last_found_words) <= 10) {

--- a/src/Bojler/GameStatus.php
+++ b/src/Bojler/GameStatus.php
@@ -207,27 +207,14 @@ class GameStatus #not final because of mocking
         return new Collator(CONFIG->getLocale($this->current_lang));
     }
 
-    public function currentEntryJson()
+    public function currentEntryJson(): CurrentGameData # TODO the name will eventually lose the JSON
     {
         return CurrentGameData::fromStatusObject($this);
     }
 
-    public function currentEntryLegacy()
+    public function currentEntryLegacy(): string
     {
-        $space_separated_letters = implode(' ', $this->letters->list);
-        $space_separated_found_words = implode(' ', $this->found_words->toArray());
-        return <<<END
-            #Current Game
-            $space_separated_letters
-            $space_separated_found_words
-            Game Number\t{$this->game_number}
-            Game Language\t{$this->current_lang}
-
-            # General Settings
-            Base Language\t{$this->base_lang}
-            Planned Language\t{$this->planned_lang}
-            Saved Games\t{$this->max_saved_game}
-            END;
+        return CurrentGameData::fromStatusObject($this)->toLegacyEntry();
     }
 
     public function archiveEntry()

--- a/src/Bojler/GameStatus.php
+++ b/src/Bojler/GameStatus.php
@@ -264,13 +264,13 @@ class GameStatus #not final because of mocking
         }
         $this->player_handler->newGame();
         $legacy_parsed = ArchiveGameEntryData::fromLegacyFile($this->legacy_archive_file, $number);
-        /*$json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $number);
+        $json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $number);
         if ($json_parsed != $legacy_parsed) {
             echo 'Something went wrong: the file formats don\'t align!';
             var_dump($json_parsed);
             var_dump($legacy_parsed);
             throw new Exception("File formats show inconsistent values; check the logs.");
-        }*/
+        }
         $this->letters = new LetterList($legacy_parsed->letters_sorted, true);
         if ($this->letters->isAbnormal()) {
             echo 'Game might be damaged.';
@@ -292,13 +292,13 @@ class GameStatus #not final because of mocking
             return false;
         }
         $legacy_parsed = ArchiveGameEntryData::fromLegacyFile($this->legacy_archive_file, $this->max_saved_game);
-        /*$json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $this->max_saved_game);
+        $json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $this->max_saved_game);
         if ($json_parsed != $legacy_parsed) {
             echo 'Something went wrong: the file formats don\'t align!';
             var_dump($json_parsed);
             var_dump($legacy_parsed);
             throw new Exception("File formats show inconsistent values; check the logs.");
-        }*/
+        }
         echo $legacy_parsed->current_lang;
         if ($legacy_parsed->current_lang !== $this->current_lang) {
             return false;

--- a/src/Bojler/GameStatus.php
+++ b/src/Bojler/GameStatus.php
@@ -250,6 +250,12 @@ class GameStatus #not final because of mocking
         $this->wordlist_solutions = new Set(array_filter($content, fn($line) => $this->wordValidFast($line, $refdict)));
     }
 
+    public function synchronizeArchives(): void
+    {
+        $archive_entries = array_map(fn ($number) => ArchiveGameEntryData::fromLegacyFile($this->legacy_archive_file, $number), range(1, $this->max_saved_game));
+        file_put_contents($this->jsonArchiveFile(), json_encode($archive_entries, JSON_PRETTY_PRINT|JSON_UNESCAPED_UNICODE));
+    }
+
     public function tryLoadOldGame(int $number)
     {
         $this->saveOld();
@@ -258,8 +264,8 @@ class GameStatus #not final because of mocking
         }
         $this->player_handler->newGame();
         $legacy_parsed = ArchiveGameEntryData::fromLegacyFile($this->legacy_archive_file, $number);
-        $json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $number);
-        /*if ($json_parsed != $legacy_parsed) {
+        /*$json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $number);
+        if ($json_parsed != $legacy_parsed) {
             echo 'Something went wrong: the file formats don\'t align!';
             var_dump($json_parsed);
             var_dump($legacy_parsed);
@@ -286,8 +292,8 @@ class GameStatus #not final because of mocking
             return false;
         }
         $legacy_parsed = ArchiveGameEntryData::fromLegacyFile($this->legacy_archive_file, $this->max_saved_game);
-        $json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $this->max_saved_game);
-        /*if ($json_parsed != $legacy_parsed) {
+        /*$json_parsed = ArchiveGameEntryData::fromJsonFile($this->jsonArchiveFile(), $this->max_saved_game);
+        if ($json_parsed != $legacy_parsed) {
             echo 'Something went wrong: the file formats don\'t align!';
             var_dump($json_parsed);
             var_dump($legacy_parsed);

--- a/src/bot.php
+++ b/src/bot.php
@@ -252,6 +252,17 @@ function trigger(Message $ctx, $args): void
 }
 
 $bot->registerCommand(
+    'syncar',
+    decorate_handler([async(...), ensure_predicate(from_creator(...))], synchronize_archives(...)),
+    ['description' => 'testing purposes only']
+);
+function synchronize_archives(Message $ctx): void
+{
+    GAME_STATUS->synchronizeArchives();
+    await($ctx->reply('Archives synchronized based on the legacy format.'));
+}
+
+$bot->registerCommand(
     'nextlang',
     decorate_handler([async(...), ensure_predicate(channel_valid(...))], 'next_language'),
     ['description' => 'change language']


### PR DESCRIPTION
This still may still not be the final stage of this branch but it's time to test the JSON format as a backup *for the archive files now* - the decisions are still made based on the legacy format but consistency is checked at loading and the game refuses to load when the backup doesn't align.

Since unlike the current file, this file is more like a journey than just a statically overwritten single value, there is a (temporary) command `syncar` for assisting the migration during runtime.